### PR TITLE
Update update_taxonomy.php

### DIFF
--- a/example/hooks/actions/pods_api_post_save_pod_item_podname/examples/update_taxonomy.php
+++ b/example/hooks/actions/pods_api_post_save_pod_item_podname/examples/update_taxonomy.php
@@ -15,6 +15,7 @@ function my_tax_update( $pieces, $is_new_item, $id ) {
 		$terms = null;
 	} else {
 		// create an array out of the comma separated values
+		// use this code if you want to save a single item only, if you want to save entries from a multi-select field comment this line
 		$terms = explode(',', $terms);
 		
 		// ensure all values in the array are integer (otherwise the numerical value is taken as a new taxonomy term instead of an ID)


### PR DESCRIPTION
In the recent versions of Pods
    $terms = $pieces[ 'fields' ][ 'pods_genre' ][ 'value' ]; 
if the field is a multi-select it will return an array, so we don't need to use explode(), but if it is a single field we must use explode
