### PR TITLE
Shim for meta_value_num

### DIFF
--- a/example/hooks/filters/pods_shortcode_findrecords_params/orderby_number.php
+++ b/example/hooks/filters/pods_shortcode_findrecords_params/orderby_number.php
@@ -12,8 +12,8 @@
 
 add_filter( 'pods_shortcode_findrecords_params', 'slug_orderby_by_number_pods_shortcode', 10, 2 );
 function slug_orderby_by_number_pods_shortcode( $params, $pod ) {
-	if ( isset( $params[ 'orderby' ] ) && strpos($params[ 'orderby' ], 'meta_value_num') ) {
-		$params[ 'orderby' ] = 'CAST(' . str_replace('_num', '', $params[ 'orderby' ]) . ' AS DECIMAL)';
+	if ( isset( $params[ 'orderby' ] ) && strpos($params[ 'orderby' ], '.meta_value_num') ) {
+		$params[ 'orderby' ] = 'CAST(' . str_replace('.meta_value_num', '.meta_value', $params[ 'orderby' ]) . ' AS DECIMAL)';
 	}
 
 	return $params;

--- a/example/hooks/filters/pods_shortcode_findrecords_params/orderby_number.php
+++ b/example/hooks/filters/pods_shortcode_findrecords_params/orderby_number.php
@@ -8,13 +8,13 @@
 /**
 * Example to order by a price field properly.
 */
-//SHORTCODE [pods name="ofertas" where="idprogram.meta_value='12011' and sessioncheck.meta_value='1'" limit="50" orderby="price.meta_value"  template="oferta"]
+//SHORTCODE [pods name="ofertas" where="idprogram.meta_value='12011' and sessioncheck.meta_value='1'" limit="50" orderby="price.meta_value_num" template="oferta"]
 
-add_filter( 'pods_shortcode_findrecords_params', 'slug_orderby_by_price_pods_shortcode', 10, 2 );
-function slug_orderby_by_price_pods_shortcode( $params, $pod ) {
-  if ( 'ofertas' == $pod->pod && isset( $params[ 'orderby' ] ) && $params[ 'orderby' ] == 'price.meta_value' ) {
-    $params[ 'orderby' ] = 'CAST(price.meta_value AS DECIMAL)';
-  }
-  
-  return $params;
+add_filter( 'pods_shortcode_findrecords_params', 'slug_orderby_by_number_pods_shortcode', 10, 2 );
+function slug_orderby_by_number_pods_shortcode( $params, $pod ) {
+	if ( isset( $params[ 'orderby' ] ) && strpos($params[ 'orderby' ], 'meta_value_num') ) {
+		$params[ 'orderby' ] = 'CAST(' . str_replace('_num', '', $params[ 'orderby' ]) . ' AS DECIMAL)';
+	}
+
+	return $params;
 }


### PR DESCRIPTION
Use the [`WP_Query` way](https://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters) of telling `orderby` to look at numbers instead of strings. If you've set up custom field with a type of "Plain Number", you can sort by that field using:

`[pods name="posttype" template="Template" orderby="price.meta_value_num"]`

...instead of what's required currently:

`[pods name="posttype" template="Template" orderby="CAST(price.meta_value AS DECIMAL)"]`